### PR TITLE
Add minimal SwiftUI iOS app example

### DIFF
--- a/simple-ios-app/ContentView.swift
+++ b/simple-ios-app/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/simple-ios-app/README.md
+++ b/simple-ios-app/README.md
@@ -1,0 +1,7 @@
+# Simple iOS App
+
+A minimal SwiftUI iOS application that displays "Hello, world!" on screen.
+
+## Building
+
+Open the project in Xcode 12 or later and run on an iOS 14 or later simulator or device.

--- a/simple-ios-app/SimpleIOSApp.swift
+++ b/simple-ios-app/SimpleIOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct SimpleIOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple SwiftUI app displaying 'Hello, world!'
- document how to build the example

## Testing
- `swiftc simple-ios-app/SimpleIOSApp.swift simple-ios-app/ContentView.swift -o simple-ios-app/app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6890991fabb08320807e5ad48e6aae29